### PR TITLE
Updated to JS Beautify 1.4.0 to resolve IE Conditional Comments bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "js-beautify": "~1.3.1"
+    "js-beautify": "~1.4.0"
   },
   "devDependencies": {
     "assemble": "~0.3.72",


### PR DESCRIPTION
This resolves https://github.com/jonschlinkert/grunt-prettify/issues/2.

I would like to test this change before submitting a pull request but the unit tests don't seem to be running properly. `prettify_test.js` is looking for a directory at `test/expected` but this does not exist.
