### PR TITLE
Option docs doesn't have the correct default values

### DIFF
--- a/docs/prettify-options.md
+++ b/docs/prettify-options.md
@@ -41,7 +41,7 @@ Character with which to indent the output HTML.
 
 ## indent_scripts
 Type: `String`
-Default value: `normal`
+Default value: `keep`
 Options: `keep`|`separate`|`normal`
 
 The indentation character to use to indent the output HTML.
@@ -54,7 +54,7 @@ Indent `<body></body>` and `<head></head>` sections.
 
 ## brace_style
 Type: `String`
-Default value: `collapse`
+Default value: `expand`
 
 Options:
 
@@ -70,7 +70,7 @@ Maximum characters per line. `0` disables, max is `250`.
 
 ## preserve_newlines
 Type: `Boolean`
-Default value: `true`
+Default value: `false`
 
 Preserve existing line-breaks.
 


### PR DESCRIPTION
Shouldn't the doc's defaults match these values?

```
    // Merge task-specific and/or target-specific options with these defaults.
    var options = this.options({
      indent: 2,
      indent_char: " ",
      indent_inner_html: true,
      indent_scripts: "keep",
      brace_style: "expand",
      preserve_newline: false,
      max_preserve_newline: 0,
      wrap_line_length: 0
    });
```

https://github.com/jonschlinkert/grunt-prettify/blob/master/tasks/prettify.js#L20
