### PR TITLE
Update vulnerable packages to latest supported versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "assemble": "~0.4.27",
     "grunt": "~0.4.2",
+    "grunt-readme": "^0.4.5",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-jshint": "~0.7.2",
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -28,18 +28,18 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "async": "~0.9.0",
-    "globby": "^0.1.1",
-    "js-beautify": "~1.5.4",
-    "lodash": "~2.4.1",
-    "underscore.string": "~2.3.3"
+    "async": "^3.2.4",
+    "globby": "^11.1.0",
+    "js-beautify": "^1.14.0",
+    "lodash": "^4.17.21",
+    "underscore.string": "^3.3.6"
   },
   "devDependencies": {
     "assemble": "~0.4.27",
     "grunt": "~0.4.2",
-    "grunt-readme": "^0.4.5",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-jshint": "~0.7.2",
+    "grunt-readme": "^0.4.5",
     "mocha": "*",
     "verb": ">= 0.2.6"
   },

--- a/tasks/prettify.js
+++ b/tasks/prettify.js
@@ -12,7 +12,6 @@
  */
 
 var fs = require('fs');
-var path = require('path');
 var glob = require('globby');
 var prettify = require('js-beautify').html;
 var _str = require('underscore.string');

--- a/test/actual/custom_indentation/gist.html
+++ b/test/actual/custom_indentation/gist.html
@@ -53,9 +53,7 @@
     grunt.fail.warn(<span class="string">'HTML prettification failed.'</span>);
   }
 };</code></pre>
-      <p>
-        <br>
-      </p>
+      <p><br></p>
       <script src="https://gist.github.com/5898072.js"></script>
       <script src="https://gist.github.com/5898077.js"></script>
     </div>

--- a/test/actual/defaults/gist.html
+++ b/test/actual/defaults/gist.html
@@ -53,9 +53,7 @@
     grunt.fail.warn(<span class="string">'HTML prettification failed.'</span>);
   }
 };</code></pre>
-      <p>
-        <br>
-      </p>
+      <p><br></p>
       <script src="https://gist.github.com/5898072.js"></script>
       <script src="https://gist.github.com/5898077.js"></script>
     </div>

--- a/test/actual/jsbeautifyrc/gist.html
+++ b/test/actual/jsbeautifyrc/gist.html
@@ -53,9 +53,7 @@
     grunt.fail.warn(<span class="string">'HTML prettification failed.'</span>);
   }
 };</code></pre>
-      <p>
-        <br>
-      </p>
+      <p><br></p>
       <script src="https://gist.github.com/5898072.js"></script>
       <script src="https://gist.github.com/5898077.js"></script>
     </div>

--- a/test/actual/padcomments/gist.html
+++ b/test/actual/padcomments/gist.html
@@ -53,9 +53,7 @@
     grunt.fail.warn(<span class="string">'HTML prettification failed.'</span>);
   }
 };</code></pre>
-      <p>
-        <br>
-      </p>
+      <p><br></p>
       <script src="https://gist.github.com/5898072.js"></script>
       <script src="https://gist.github.com/5898077.js"></script>
     </div>


### PR DESCRIPTION
Fixes #32 
(I hope)

There are many security advisories out for some dependencies of this project. I know it was last updated 8 years ago, but many packages still have this somewhere in their dependency trees, so it's good to fix these updates and keep everybody's code secure.

Notes:
- I couldn't update `globby` to latest, as the latest few major versions dropped support for commonjs modules. Other packages were updated to their latest versions (I left devDependencies alone, as I was having trouble getting things to build correctly otherwise)

There is a minor formatting change to the output of this package with this; some of the test files output some tags on a single line instead of multiple lines. Otherwise the tests seem unaffected.


Let me know if there's a better way to test this than running the test suite and I'd be happy to help out.
